### PR TITLE
Require setuptools in run

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 2dc86fe0476e945e61483d614ceb2cf4f93b95282eb243bdf792621994360383
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -19,9 +18,9 @@ requirements:
     - gettext
     - python
     - setuptools
-
   run:
     - python
+    - setuptools
 
 test:
   requires:


### PR DESCRIPTION
As the entrypoints are not generated by conda (we cannot use `noarch` here due to the scripts), we need to also install `setuptools` as `pkg_resources` is used in them.


Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
