### PR TITLE
Add back $PREFIX/etc/supervisord.conf link and this render function

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ function render()
     mkdir -p $2
 
     cp $src_file $dst_file
-    sed -i "s;\$PREFIX;$PREFIX;g" $dst_file
+    sed -i "s;\${PREFIX};$PREFIX;g" $dst_file
 }
 
 function mkdir_touch()

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,6 +29,10 @@ mkdir_touch $PREFIX/var/log
 mkdir_touch $PREFIX/var/run
 
 render $RECIPE_DIR/supervisord.conf $PREFIX/etc/supervisord/
+# Create a symlink in $PREFIX/etc so that supervisorctl can find the config file:
+# ../etc/supervisord.conf (Relative to the executable).
+# See https://supervisord.org/configuration.html
+ln -s $PREFIX/etc/supervisord/supervisord.conf $PREFIX/etc/supervisord.conf
 
 mkdir -p $PREFIX/etc/rc.d/init.d/
 render $RECIPE_DIR/Debian-supervisord $PREFIX/etc/rc.d/init.d/

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 4a2bf149adf42997e1bb44b70c43b613275ec9852c3edacca86a9166b27e945e
 
 build:
-  number: 1
+  number: 2
   noarch: python
   python:
     entry_points:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fix #58 

* Add back `$PREFIX/etc/supervisord.conf` link, which is required for `supervisorctl` to find the config file under `../etc/supervisord.conf`.
* Fix the render function in build. It was trying to replace `$PREFIX` instead of `${PREFIX}`. Meaning it wasn't replaced and the default config file was invalid... Looks like it was broken a while ago. I guess most people overwrite the config file.
